### PR TITLE
Add  _get_android_dependencies

### DIFF
--- a/GodotAndroidYandexAds/export_scripts/export_plugin.gd
+++ b/GodotAndroidYandexAds/export_scripts/export_plugin.gd
@@ -26,6 +26,14 @@ class AndroidExportPlugin extends EditorExportPlugin:
 			return PackedStringArray([_plugin_name + "/bin/debug/" + _plugin_name + "-debug.aar"])
 		else:
 			return PackedStringArray([_plugin_name + "/bin/release/" + _plugin_name + "-release.aar"])
+	
+
+	func _get_android_dependencies(platform, debug):
+		if debug:
+			return PackedStringArray(["com.yandex.android:mobileads:7.1.0"])
+		else:
+			return PackedStringArray(["com.yandex.android:mobileads:7.1.0"])
+
 
 	func _get_name():
 		return _plugin_name


### PR DESCRIPTION
Привет.
Тогда не нужно будет в build.gradle  добавлять зависимости:

> dependencies {
>     ...
>     implementation "com.yandex.android:mobileads:7.1.0"
> }